### PR TITLE
Implement sepBy

### DIFF
--- a/examples/jsonc.py
+++ b/examples/jsonc.py
@@ -61,10 +61,9 @@ def quoted():
 def array():
     '''Parse array element in JSON text.'''
     yield lbrack
-    first = yield value
-    rest = yield many((comma >> value))
+    elements = yield sepBy(value, comma)
     yield rbrack
-    return [first] + rest
+    return elements
 
 @generate
 def object_pair():
@@ -78,10 +77,9 @@ def object_pair():
 def json_object():
     '''Parse json object.'''
     yield lbrace
-    first = yield object_pair
-    rest = yield many(comma >> object_pair)
+    pairs = yield sepBy(object_pair, comma)
     yield rbrace
-    return dict([first] + rest)
+    return dict(pairs)
 
 value = quoted | number() | json_object | array | true | false | null
 

--- a/examples/test_json.py
+++ b/examples/test_json.py
@@ -18,7 +18,7 @@ class TestJsonc(unittest.TestCase):
     '''Test the implementation of JSON parser.'''
     def test_simple(self):
         self.assertEqual(
-            jsonc.parse('{"a": "true", "b": false, "C": ["a", "b", "C"]}'), 
+            jsonc.parse('{"a": "true", "b": false, "C": ["a", "b", "C"]}'),
             {"a": "true", "b": False, "C": ["a", "b", "C"]})
 
     def test_number(self):
@@ -39,9 +39,9 @@ class TestJsonc(unittest.TestCase):
             {
                 "a": {
                     "a": "x",
-                    "b": "t", 
+                    "b": "t",
                     "c": {
-                        "a": true, 
+                        "a": true,
                         "c": [true, false, true]
                     }
                 }
@@ -50,6 +50,11 @@ class TestJsonc(unittest.TestCase):
         self.assertEqual(result['a']['a'], 'x')
         self.assertEqual(result['a']['c']['a'], True)
         self.assertEqual(result['a']['c']['c'], [True, False, True])
+
+    def test_empty(self):
+        self.assertEqual(jsonc.parse('{}'), {})
+        result = jsonc.parse('{"a":[]}')
+        self.assertEqual(result['a'], [])
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/parsec/__init__.py
+++ b/src/parsec/__init__.py
@@ -381,6 +381,79 @@ def many1(p):
     Return a list of values.'''
     return times(p, 1, float('inf'))
 
+def separated(p, sep, mint, maxt=None, end=None):
+    '''Repeat a parser `p` separated by `s` between `mint` and `maxt` times.
+    When `end` is None, a trailing separator is optional.
+    When `end` is True, a trailing separator is required.
+    When `end` is False, a trailing separator is not allowed.
+    MATCHES AS MUCH AS POSSIBLE.
+    Return list of values returned by `p`.'''
+    maxt = maxt if maxt else mint
+    @Parser
+    def sep_parser(text, index):
+        cnt, values, res = 0, Value.success(index, []), None
+        while cnt < maxt:
+            if end in [False, None] and cnt > 0:
+                res = sep(text, index)
+                if res.status: ## `sep` found, consume it (advance index)
+                    index, values = res.index, Value.success(res.index, values.value)
+                elif cnt < mint:
+                    return res ## error: need more elemnts, but no `sep` found.
+                else:
+                    break
+
+            res = p(text, index)
+            if res.status:
+                values = values.aggregate(Value.success(res.index, [res.value]))
+                index, cnt = res.index, cnt+1
+            elif cnt >= mint:
+                break
+            else:
+                return res ## error: need more elements, but no `p` found.
+
+            if end is True:
+                res = sep(text, index)
+                if res.status:
+                    index, values = res.index, Value.success(res.index, values.value)
+                else:
+                    return res # error: trailing `sep` not found
+
+            if cnt >= maxt:
+                break
+        return values
+    return sep_parser
+
+def sepBy(p, sep):
+    '''`sepBy(p, sep)` parses zero or more occurrences of p, separated by `sep`.
+    Returns a list of values returned by `p`.'''
+    return separated(p, sep, 0, maxt=float('inf'), end=False)
+
+def sepBy1(p, sep):
+    '''`sepBy1(p, sep)` parses one or more occurrences of `p`, separated by
+    `sep`. Returns a list of values returned by `p`.'''
+    return separated(p, sep, 1, maxt=float('inf'), end=False)
+
+def endBy(p, sep):
+    '''`endBy(p, sep)` parses zero or more occurrences of `p`, seperated and
+    ended by `sep`. Returns a list of values returned by `p`.'''
+    return separated(p, sep, 0, maxt=float('inf'), end=True)
+
+def endBy1(p, sep):
+    '''`endBy1(p, sep) parses one or more occurrences of `p`, seperated and
+    ended by `sep`. Returns a list of values returned by `p`.'''
+    return separated(p, sep, 1, maxt=float('inf'), end=True)
+
+def sepEndBy(p, sep):
+    '''`sepEndBy(p, sep)` parses zero or more occurrences of `p`, separated and
+    optionally ended by `sep`. Returns a list of
+    values returned by `p`.'''
+    return separated(p, sep, 0, maxt=float('inf'))
+
+def sepEndBy1(p, sep):
+    '''`sepEndBy1(p, sep)` parses one or more occurrences of `p`, separated and
+    optionally ended by `sep`. Returns a list of values returned by `p`.'''
+    return separated(p, sep, 1, maxt=float('inf'))
+
 ##########################################################################
 ## Text.Parsec.Char
 ##########################################################################

--- a/tests/test_parsec.py
+++ b/tests/test_parsec.py
@@ -167,6 +167,84 @@ class ParsecCombinatorTest(unittest.TestCase):
         self.assertRaises(ParseError, parser.parse, '')
         self.assertRaises(ParseError, parser.parse, '1')
 
+    def test_separated(self):
+        parser = separated(string('x'), string(','), 2, 4)
+        self.assertEqual(parser.parse('x,x,x') , ['x', 'x', 'x'])
+        self.assertEqual(parser.parse('x,x,x,'), ['x', 'x', 'x'])
+        self.assertRaises(ParseError, parser.parse, 'x')
+        self.assertRaises(ParseError, parser.parse, 'x,')
+        self.assertRaises(ParseError, parser.parse, 'x,y,y,y,y')
+        self.assertRaises(ParseError, parser.parse, 'x,y,y,y,y,')
+        self.assertEqual(parser.parse('x,x,y,y' ), ['x','x'])
+        self.assertEqual(parser.parse('x,x,y,y,'), ['x','x'])
+
+        parser = separated(letter(), string(','), 0)
+        self.assertEqual(parser.parse('')          , [])
+        self.assertEqual(parser.parse('x')         , [])
+        self.assertEqual(parser.parse('x,')        , [])
+        self.assertEqual(parser.parse('x,x,x,x,x') , [])
+        self.assertEqual(parser.parse('x,x,x,x,x,'), [])
+
+    def test_sepBy(self):
+        parser = sepBy(letter(), string(','))
+        self.assertEqual(parser.parse_strict('x')     , ['x'])
+        self.assertEqual(parser.parse       ('x,')    , ['x'])
+        self.assertEqual(parser.parse_strict('x,y,z') , ['x', 'y', 'z'])
+        self.assertEqual(parser.parse       ('x,y,z,'), ['x', 'y', 'z'])
+        self.assertEqual(parser.parse       ('') , [])  # nothing consumed
+        self.assertEqual(parser.parse       ('1'), [])  # nothing consumed
+        self.assertEqual(parser.parse       ('1,'), []) # nothing consumed
+
+    def test_sepBy1(self):
+        parser = sepBy1(letter(), string(','))
+        self.assertEqual(parser.parse_strict('x')     , ['x'])
+        self.assertEqual(parser.parse       ('x,')    , ['x'])
+        self.assertEqual(parser.parse_strict('x,y,z') , ['x', 'y', 'z'])
+        self.assertEqual(parser.parse       ('x,y,z,'), ['x', 'y', 'z'])
+        self.assertRaises(ParseError, parser.parse, (''))
+        self.assertRaises(ParseError, parser.parse, ('1'))
+        self.assertRaises(ParseError, parser.parse, ('1,'))
+
+    def test_endBy(self):
+        parser = endBy(letter(), string(','))
+        self.assertRaises(ParseError, parser.parse, ('x'))
+        self.assertRaises(ParseError, parser.parse, ('x,y,z'))
+        self.assertEqual(parser.parse_strict('x,')    , ['x'])
+        self.assertEqual(parser.parse_strict('x,y,z,'), ['x', 'y', 'z'])
+        self.assertEqual(parser.parse       ('')      , [])
+        self.assertEqual(parser.parse       ('1')     , [])
+        self.assertEqual(parser.parse       ('1,')    , [])
+
+    def test_endBy1(self):
+        parser = endBy1(letter(), string(','))
+        self.assertRaises(ParseError, parser.parse, ('x'))
+        self.assertRaises(ParseError, parser.parse, ('x,y,z'))
+        self.assertEqual(parser.parse_strict('x,')    , ['x'])
+        self.assertEqual(parser.parse_strict('x,y,z,'), ['x', 'y', 'z'])
+        self.assertRaises(ParseError, parser.parse, (''))
+        self.assertRaises(ParseError, parser.parse, ('1'))
+        self.assertRaises(ParseError, parser.parse, ('1,'))
+
+    def test_sepEndBy(self):
+        parser = sepEndBy(letter(), string(','))
+        self.assertEqual(parser.parse_strict('x')     , ['x'])
+        self.assertEqual(parser.parse_strict('x,')    , ['x'])
+        self.assertEqual(parser.parse_strict('x,y,z') , ['x', 'y', 'z'])
+        self.assertEqual(parser.parse_strict('x,y,z,'), ['x', 'y', 'z'])
+        self.assertEqual(parser.parse       ('')      , [])
+        self.assertEqual(parser.parse       ('1')     , [])
+        self.assertEqual(parser.parse       ('1,')    , [])
+
+    def test_sepEndBy1(self):
+        parser = sepEndBy1(letter(), string(','))
+        self.assertEqual(parser.parse_strict('x')     , ['x'])
+        self.assertEqual(parser.parse_strict('x,')    , ['x'])
+        self.assertEqual(parser.parse_strict('x,y,z') , ['x', 'y', 'z'])
+        self.assertEqual(parser.parse_strict('x,y,z,'), ['x', 'y', 'z'])
+        self.assertRaises(ParseError, parser.parse, (''))
+        self.assertRaises(ParseError, parser.parse, ('1'))
+        self.assertRaises(ParseError, parser.parse, ('1,'))
+
 class ParsecCharTest(unittest.TestCase):
     '''Test the implementation of Text.Parsec.Char.'''
 


### PR DESCRIPTION
This implements the `sepBy`, `endBy` and `sepEndBy` variations found in parsec,
which allow easy parsing of separated lists.

I've also updated the jsonc example to use this, which lets it support
empty arrays and objects easily.


