### PR TITLE
Fix several typos

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,7 +5,7 @@
 .. meta::
    :http-equiv=Content-Type: text/html; charset=utf-8
    :keywords: python, parser, combinator
-   :description lang=en: A univeral Python parser combinator library inspirted by Parsec library of Haskell.
+   :description lang=en: A universal Python parser combinator library inspired by Parsec library of Haskell.
 
 Parsec: A parser combinator library in Python
 *********************************************
@@ -19,13 +19,13 @@ What's the parsec.py ?
     :noindex:
 
 Parser combinator is a technique to implement a parser. A parser combinator is a function (higher-order function)
-that accecpts serveval parsers as arguments and return a new parser as result. Parser combinators enable a recursive
+that accepts several parsers as arguments and return a new parser as result. Parser combinators enable a recursive
 descent parsing strategy, this parsing technique facilitates modular piecewise construction and testing. Parser
-combinators can be used to combine basic parsers to construct parsers for more complex rules, and parser built 
-using combinators are straightforward to construct, readable, modular, well-structured and easilly maintainable.
+combinators can be used to combine basic parsers to construct parsers for more complex rules, and parser built
+using combinators are straightforward to construct, readable, modular, well-structured and easily maintainable.
 
 `The parsec package <https://hackage.haskell.org/package/parsec>`_ is a famous monadic parser combinator library
-in Haskell. Now, the parsec is a parser combinator library implmented in Python, providing Python developers an
+in Haskell. Now, the parsec is a parser combinator library implemented in Python, providing Python developers an
 easy and elegant approach to build a complex but efficient parser.
 
 Let's go ahead to see the MAGIC of parser combinators!
@@ -33,13 +33,13 @@ Let's go ahead to see the MAGIC of parser combinators!
 Examples
 ========
 
-The design of parsec's API was inspirted by Parsec library of Haskell.
+The design of parsec's API was inspired by Parsec library of Haskell.
 
 Simple parser primitives
 -------------------------
 
 
-For more details about this library, see it's documentation at 
+For more details about this library, see it's documentation at
 
 .. toctree::
     :maxdepth: 2
@@ -50,7 +50,7 @@ Usage and Contributor Guide
 ============================
 
 This project is open-source under `The MIT License <http://mit-license.org>`_ and you may use, distribute and
-modify this code with out limitation. The source code can be found at 
+modify this code with out limitation. The source code can be found at
 `the site hosted on github <https://github.com/sighingnow/parsec.py>`_.
 
 * You can install this library using `pip <https://pypi.python.org/pypi/pip>`_ with the following command:


### PR DESCRIPTION
A couple of typos that I noticed while reading http://pythonhosted.org/parsec/