### PR TITLE
Fix a bug in the implement of `joint`.

### DIFF
--- a/src/parsec/__init__.py
+++ b/src/parsec/__init__.py
@@ -293,7 +293,7 @@ def joint(*parsers):
             if prev_v:
                 index = prev_v.index
             prev_v = v = p(text, index)
-            if not v:
+            if not v.status:
                 return v
             values.append(v)
         return Value.combinate(values)

--- a/tests/test_parsec.py
+++ b/tests/test_parsec.py
@@ -74,6 +74,17 @@ class ParsecPrimTest(unittest.TestCase):
         self.assertRaises(ParseError, parser.parse, 'y')
         self.assertRaises(ParseError, parser.parse, 'z')
 
+        nonlocals = {'changed': False}
+
+        @generate
+        def fn():
+            nonlocals['changed'] = True
+            yield string('y')
+
+        parser = string('x') + fn
+        self.assertRaises(ParseError, parser.parse, '1')
+        self.assertEqual(nonlocals['changed'], False)
+
     def test_choice(self):
         parser = string('x') | string('y')
         self.assertEqual(parser.parse('x'), 'x')


### PR DESCRIPTION
Fix a bug in the implement of `joint`, change it to properly use minimal evaluation.