### PR TITLE
Improve JSONC Example

### DIFF
--- a/examples/jsonc.py
+++ b/examples/jsonc.py
@@ -42,6 +42,7 @@ def charseq():
         return string('\\') >> (
             string('\\')
             | string('/')
+            | string('"')
             | string('b').result('\b')
             | string('f').result('\f')
             | string('n').result('\n')

--- a/examples/test_json.py
+++ b/examples/test_json.py
@@ -27,6 +27,7 @@ class TestJsonc(unittest.TestCase):
 
     def test_quoted(self):
         self.assertEqual(jsonc.parse('{"a": "b"}'), {"a": "b"})
+        self.assertEqual(jsonc.parse('{"a": "b\\""}'), {"a": "b\""})
 
     def test_array(self):
         result = jsonc.parse('{"a": ["a", ["b", true], "d"]}')


### PR DESCRIPTION
Handle escaped double quotes: \\"