### PR TITLE
Add Python 3.7 to Travis CI and fix test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
+dist: xenial
+
 language: python
 
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 # command to install dependencies.
 install: true

--- a/src/parsec/__init__.py
+++ b/src/parsec/__init__.py
@@ -394,6 +394,13 @@ def generate(fn):
                 return endval(text, index)
             else:
                 return Value.success(index, endval)
+        except RuntimeError as error:
+            stop = error.__cause__
+            endval = stop.value
+            if isinstance(endval, Parser):
+                return endval(text, index)
+            else:
+                return Value.success(index, endval)
     return generated.desc(fn.__name__)
 
 


### PR DESCRIPTION
Python 3.7 fully implements PEP 479, which changes the behavior of raising StopIteration inside generator functions. (See https://www.python.org/dev/peps/pep-0479/ for details.)

Prior to 5d6a884, the tests would fail:
```
...
test_generate_raise (tests.test_parsec.ParserGeneratorTest) ... ERROR

======================================================================
ERROR: test_generate_raise (tests.test_parsec.ParserGeneratorTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/chbrown/src/parsec.py/tests/test_parsec.py", line 346, in xy
    raise r
StopIteration: success

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/chbrown/src/parsec.py/tests/test_parsec.py", line 349, in test_generate_raise
    self.assertEqual(parser.parse('xy'), 'success')
  File "/Users/chbrown/src/parsec.py/src/parsec/__init__.py", line 115, in parse
    return self.parse_partial(text)[0]
  File "/Users/chbrown/src/parsec.py/src/parsec/__init__.py", line 124, in parse_partial
    res = self(text, 0)
  File "/Users/chbrown/src/parsec.py/src/parsec/__init__.py", line 111, in __call__
    return self.fn(text, index)
  File "/Users/chbrown/src/parsec.py/src/parsec/__init__.py", line 172, in choice_parser
    res = self(text, index)
  File "/Users/chbrown/src/parsec.py/src/parsec/__init__.py", line 111, in __call__
    return self.fn(text, index)
  File "/Users/chbrown/src/parsec.py/src/parsec/__init__.py", line 386, in generated
    parser = iterator.send(value)
RuntimeError: generator raised StopIteration

----------------------------------------------------------------------
Ran 47 tests in 0.012s

FAILED (errors=1)
```