### PR TITLE
Add utilities

### DIFF
--- a/src/parsec/__init__.py
+++ b/src/parsec/__init__.py
@@ -111,7 +111,7 @@ class Parser(object):
         return self.fn(text, index)
 
     def parse(self, text):
-        '''Parser a given string `text`.'''
+        '''Parses a given string `text`.'''
         return self.parse_partial(text)[0]
 
     def parse_partial(self, text):
@@ -567,7 +567,7 @@ def sepEndBy1(p, sep):
 
 
 def one_of(s):
-    '''Parser a char from specified string.'''
+    '''Parses a char from specified string.'''
     @Parser
     def one_of_parser(text, index=0):
         if index < len(text) and text[index] in s:
@@ -578,7 +578,7 @@ def one_of(s):
 
 
 def none_of(s):
-    '''Parser a char NOT from specified string.'''
+    '''Parses a char NOT from specified string.'''
     @Parser
     def none_of_parser(text, index=0):
         if index < len(text) and text[index] not in s:
@@ -589,7 +589,7 @@ def none_of(s):
 
 
 def space():
-    '''Parser a whitespace character.'''
+    '''Parses a whitespace character.'''
     @Parser
     def space_parser(text, index=0):
         if index < len(text) and text[index].isspace():
@@ -600,7 +600,7 @@ def space():
 
 
 def spaces():
-    '''Parser zero or more whitespace characters.'''
+    '''Parses zero or more whitespace characters.'''
     return many(space())
 
 
@@ -616,7 +616,7 @@ def letter():
 
 
 def digit():
-    '''Parse a digit character.'''
+    '''Parse a digit.'''
     @Parser
     def digit_parser(text, index=0):
         if index < len(text) and text[index].isdigit():
@@ -627,7 +627,7 @@ def digit():
 
 
 def eof():
-    '''Parser EOF flag of a string.'''
+    '''Parses EOF flag of a string.'''
     @Parser
     def eof_parser(text, index=0):
         if index >= len(text):
@@ -638,7 +638,7 @@ def eof():
 
 
 def string(s):
-    '''Parser a string.'''
+    '''Parses a string.'''
     @Parser
     def string_parser(text, index=0):
         slen, tlen = len(s), len(text)
@@ -653,7 +653,7 @@ def string(s):
 
 
 def regex(exp, flags=0):
-    '''Parser according to a regular expression.'''
+    '''Parses according to a regular expression.'''
     if isinstance(exp, str):
         exp = re.compile(exp, flags)
 


### PR DESCRIPTION
This PR adds the following utilities:

`fail_with(message)` always fails with `message`
Useful when combining parsers with `^` and you want to give a nice error msg

`exclude(p, excl)` fails parser `p` if parser `excl` matches
Super powerful when combined with e.g. `many()` to parse until a condition is met.
This is a bit like `separated(p, excl, mint=1, maxt=1, end=True)` except that `end` must *not* exist

`lookahead(p)` parses without consuming
This helps to disambiguate before parsing, simplifying error scenarios.

`unit(p)` converts a parser into a single unit
Allows combined parsers to act as "all or nothing", this can sometimes be much easier than using `^`

p.s.: I also fixed some minor typos in the existing docs.