### PR TITLE
Fixed a fragility in exclude(). Now requires: python >=3.6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'parsec',
-    version = '3.12',
+    version = '3.13',
     description = 'parser combinator.',
     long_description = 'A universal Python parser combinator library inspired by Parsec library of Haskell.',
     author = 'He Tao',
@@ -20,13 +20,7 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/src/parsec/__init__.py
+++ b/src/parsec/__init__.py
@@ -741,7 +741,7 @@ def exclude(p: Parser, exclude: Parser):
     def exclude_parser(text, index):
         res = exclude(text, index)
         if res.status:
-            return Value.failure(index, f"something other than {res.value}")
+            return Value.failure(index, 'something other than {}'.format(res.value))
         else:
             return p(text, index)
     return exclude_parser

--- a/src/parsec/__init__.py
+++ b/src/parsec/__init__.py
@@ -741,7 +741,7 @@ def exclude(p: Parser, exclude: Parser):
     def exclude_parser(text, index):
         res = exclude(text, index)
         if res.status:
-            return Value.failure(index, 'something other than %s' %res.value)
+            return Value.failure(index, f"something other than {res.value}")
         else:
             return p(text, index)
     return exclude_parser


### PR DESCRIPTION
I fixed a fragility in the `exclude()` parser involving sensitivity to non-string types.
However, to do this I used: `f"..."`, which means the code is no longer compatible with versions of Python <3.6!
